### PR TITLE
Add dbl rectify

### DIFF
--- a/src/alert/alert.go
+++ b/src/alert/alert.go
@@ -24,6 +24,7 @@ var logFile *os.File
 var sentry *raven.Client
 var lastSentryHour time.Time
 var sentryCnt int
+var panicOnExit bool
 
 func username() string {
 	user, err := user.Current()
@@ -43,6 +44,11 @@ func stacktrace() string {
 	}
 
 	return result
+}
+
+// PanicOnExit will cause the alert package to call panic() instead of os.exit()
+func PanicOnExit() {
+	panicOnExit = true
 }
 
 // Set configures the alert settings
@@ -292,6 +298,10 @@ func WarnOn(err error, msg string) {
 // Exit ...
 func Exit(msg string) {
 	send(raven.ERROR, "Exit: "+msg)
+	if panicOnExit {
+		err := fmt.Errorf(msg)
+		panic(err)
+	}
 	os.Exit(1)
 }
 

--- a/src/dbl/dbl.go
+++ b/src/dbl/dbl.go
@@ -69,6 +69,29 @@ func Floor(x float64, unit float64) float64 {
 	return float64(units) * unit
 }
 
+// Rectify brings the supplied value closer to the precision.
+// It should be used when a value is expected to be an integer
+// multiple of the unit, but due to repeated computations the value
+// may have diverged.
+//
+// (35.4501, 0.01) => (35.45 +- 1e-8)
+//
+func Rectify(x *float64, unit float64) {
+	if IsZero(unit) {
+		return
+	}
+
+	switch {
+	case *x < 0:
+		units := uint64((-(*x) + unit*0.01) / unit)
+		*x = float64(units) * unit * -1.0
+
+	default:
+		units := uint64((*x + unit*0.01) / unit)
+		*x = float64(units) * unit
+	}
+}
+
 // SafeDiv performs safe division of two numbers i.e. if the divisor
 // is zero, it returns zero
 func SafeDiv(x float64, y float64) float64 {

--- a/src/dbl/dbl_test.go
+++ b/src/dbl/dbl_test.go
@@ -41,3 +41,45 @@ func TestDbl(t *testing.T) {
 	assert.Equal(SafeDiv(7.0, 2.0), 3.5, "SafeDiv failed")
 	assert.Equal(SafeDiv(1.0, 0.0), 0.0, "SafeDiv failed")
 }
+
+func TestRectify(t *testing.T) {
+	assert := assert.New(t)
+
+	x := 45.03
+	Rectify(&x, 0.01)
+	assert.Equal(x, 45.03)
+
+	// Rectify 10% Error
+	x = 45.031
+	Rectify(&x, 0.01)
+	assert.Equal(x, 45.03)
+
+	x = -45.031
+	Rectify(&x, 0.01)
+	assert.Equal(x, -45.03)
+
+	// Don't Rectify
+	x = 45.03000001
+	assert.NotEqual(x, 45.03)
+
+	// Rectify
+	Rectify(&x, 0.01)
+	assert.Equal(x, 45.03)
+
+	/////////////////////////////////////
+	// Exhibit Divergence Then Rectify //
+	/////////////////////////////////////
+
+	// Add A Penny 100000 Times
+	x = 45.03
+	for i := 0; i < 100000; i++ {
+		x += 0.01
+	}
+
+	// Diverged!
+	assert.NotEqual(x, 1045.03)
+
+	// Rectify
+	Rectify(&x, 0.01)
+	assert.Equal(x, 1045.03)
+}


### PR DESCRIPTION
Added function Rectify to allow users to restore values to their precision-unit after divergence. Divergence usually piles up on repeated calculations - see `dbl_test.go`.

Also added a `PanicOnExit` option to `alert`